### PR TITLE
Fix Vulkan validation issue with uniform shader memory barriers

### DIFF
--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -766,7 +766,11 @@ namespace Veldrid.Vk
             barrier.pNext = null;
             vkCmdPipelineBarrier(
                 _cb,
-                VkPipelineStageFlags.Transfer, VkPipelineStageFlags.VertexInput,
+                VkPipelineStageFlags.Transfer, needToProtectUniform ?
+                    VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.ComputeShader |
+                    VkPipelineStageFlags.FragmentShader | VkPipelineStageFlags.GeometryShader |
+                    VkPipelineStageFlags.TessellationControlShader | VkPipelineStageFlags.TessellationEvaluationShader
+                    : VkPipelineStageFlags.VertexInput,
                 VkDependencyFlags.None,
                 1, ref barrier,
                 0, null,


### PR DESCRIPTION
Previous fix introduced some Vulkan validation errors in the memory barriers. Fix these by scoping the uniform barrier against the shaders instead of the vertex buffer.